### PR TITLE
Upgrade soon-to-be deprecated features in Django

### DIFF
--- a/csc_new/csc_new/settings.py
+++ b/csc_new/csc_new/settings.py
@@ -14,9 +14,26 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Template Directories
-TEMPLATE_DIRS = (
-    'csc_new/templates',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS' : [
+            'csc_new/templates',
+        ],
+        'APP_DIRS' : True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
 # Reference our custom Member model as the default user model
 #AUTH_USER_MODEL = 'member.Member'
@@ -41,12 +58,12 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    'django.contrib.sessions',
     'django.contrib.messages',
+    'django.contrib.sessions',
     'django.contrib.staticfiles',
+
 	'pages',
 #	'member',
-	'django.contrib.webdesign',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/csc_new/csc_new/urls.py
+++ b/csc_new/csc_new/urls.py
@@ -10,11 +10,11 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 # http://stackoverflow.com/questions/15491727/include-css-and-javascript-in-my-django-template
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Examples:
 	url(r'^$', views.index),
     url(r'^admin', include(admin.site.urls)),
-	
+
 	# Custom stuff GOES HERE
 
     # Note that "/?" at the end means a trailing
@@ -24,7 +24,7 @@ urlpatterns = patterns('',
 	url(r'^pictures/?$', views.pictures),
 	url(r'^projects/?$', views.projects),
 
-) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 urlpatterns += staticfiles_urlpatterns()
 


### PR DESCRIPTION
When attempting to run the server on the latest version of Django, I encountered several issues:

```
$ python3 manage.py runserver     
/usr/local/lib/python3.5/site-packages/django/contrib/webdesign/__init__.py:11: RemovedInDjango110Warning: django.contrib.webdesign will be removed in Django 1.10. The {% lorem %} tag is now included in the buil
t-in tags.
  RemovedInDjango110Warning

/usr/local/lib/python3.5/site-packages/django/contrib/webdesign/__init__.py:11: RemovedInDjango110Warning: django.contrib.webdesign will be removed in Django 1.10. The {% lorem %} tag is now included in the buil
t-in tags.
  RemovedInDjango110Warning

Performing system checks...

/usr/local/lib/python3.5/site-packages/django/template/utils.py:37: RemovedInDjango110Warning: You haven't defined a TEMPLATES setting. You must do so before upgrading to Django 1.10. Otherwise Django will be un
able to load templates.
  "unable to load templates.", RemovedInDjango110Warning)

System check identified no issues (0 silenced).
April 25, 2016 - 17:32:17
Django version 1.9.5, using settings 'csc_new.settings'
Starting development server at http://127.0.0.1:8000/
Quit the server with CONTROL-C.
```

So I have addressed them with this commit.
