### PR TITLE
Obfuscate email addresses across the website

### DIFF
--- a/csc_new/csc_new/settings.py
+++ b/csc_new/csc_new/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = (
 
 	'pages',
 #	'member',
+	'email_obfuscator',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/csc_new/pages/templates/csc_new/core.html
+++ b/csc_new/pages/templates/csc_new/core.html
@@ -2,6 +2,7 @@
 <html>
 	<head>
 		{% load static %}
+		{% load email_obfuscator %}
 
 		<!-- Our Style -->
 		<link href="{% static 'css/style.css' %}" rel="stylesheet" media="screen">
@@ -75,10 +76,10 @@
 				<hr />
 				<div class="lr_alt">
 					<p>
-						Send Feedback: <a href="mailto:officers@csc.cs.rit.edu">officers@csc.cs.rit.edu</a>
+						Send Feedback: {{ 'officers@csc.cs.rit.edu'|obfuscate_mailto }}
 					</p>
 					<p>
-						Join the Website Committee: <a href="mailto:committee.projects@csc.cs.rit.edu">committee.projects@csc.cs.rit.edu</a>
+						Join the Website Committee: {{ 'committee.projects@csc.cs.rit.edu'|obfuscate_mailto }}
 					</p>
 				</div>
 			</div>

--- a/csc_new/pages/templates/pages/404.html
+++ b/csc_new/pages/templates/pages/404.html
@@ -1,6 +1,7 @@
 
 {% extends "csc_new/core.html" %}
 {% load static %}
+{% load email_obfuscator %}
 
 {% block head %}
 <title>404 - RIT Computer Science Community</title>
@@ -24,7 +25,7 @@
 
     <p>
         If you believe this is an error, please contact the Computer Science Community Systems Administrator
-        <a href="mailto:admin@csc.cs.rit.edu">here</a>.
+        {{ 'admin@csc.cs.rit.edu'|obfuscate_mailto:"here" }}.
     </p>
 
     <br/>

--- a/csc_new/pages/templates/pages/about.html
+++ b/csc_new/pages/templates/pages/about.html
@@ -1,6 +1,7 @@
 
 {% extends "csc_new/base.html" %}
 {% load static %}
+{% load email_obfuscator %}
 
 {% block head %}
 <title>About - RIT Computer Science Community</title>
@@ -27,7 +28,7 @@ Who we are and what we're all about.
 		For more details, please see <a href="https://github.com/rit-csc/constitution/blob/master/constitution.md">our constitution</a>.
 	</p>
 	<p>
-		Below, you can find the name, bio, and contact email for each of our current executive board members. <!-- Want to contact the entire e-board? Message us at <i><a href="mailto:officers@csc.cs.rit.edu">officers@csc.cs.rit.edu</a></i>. -->
+		Below, you can find the name, bio, and contact email for each of our current executive board members. <!-- Want to contact the entire e-board? Message us at <i>{{ 'officers@csc.cs.rit.edu'|obfuscate_mailto }}</i>. -->
 	</p>
 </div>
 
@@ -68,7 +69,7 @@ Who we are and what we're all about.
 <div class="bio lr_alt">
 	<div>
 		<h2>Chris Lydic</h2>
-		<p><i>President</i> - <a href="mailto:president@csc.cs.rit.edu">president@csc.cs.rit.edu</a></p>
+		<p><i>President</i> - {{ 'president@csc.cs.rit.edu'|obfuscate_mailto }}</p>
 		<p>
 			I'm a second year Computer Science major interested in game design, web design, and digital art.
 		</p>
@@ -85,7 +86,7 @@ Who we are and what we're all about.
 <div class="bio lr_alt">
 	<div>
 		<h2>Zack Zatkin-Gold</h2>
-		<p><i>System Administrator</i> - <a href="mailto:admin@csc.cs.rit.edu">admin@csc.cs.rit.edu</a></p>
+		<p><i>System Administrator</i> - {{ 'admin@csc.cs.rit.edu'|obfuscate_mailto }}</a></p>
 		<p>
             I'm a fifth year Computer Science student who enjoys rock climbing, running, traveling, and photography.
 		</p>
@@ -102,7 +103,7 @@ Who we are and what we're all about.
 <div class="bio lr_alt">
 	<div>
 		<h2>Gavin Nishizawa</h2>
-		<p><i>Treasurer</i> - <a href="mailto:treasurer@csc.cs.rit.edu">treasurer@csc.cs.rit.edu</a></p>
+		<p><i>Treasurer</i> - {{ 'treasurer@csc.cs.rit.edu'|obfuscate_mailto }}</p>
 		<p>
 			I'm a third year Software Engineering major interested in puzzles, games, data structures and algorithms!
 		</p>


### PR DESCRIPTION
This patch will update the way that email addresses are encoded in the page source on certain pages of the CSC website.

Previously, we would simply write the email address in ASCII form, making it easy for spam bots to scan our webpages for email addresses. This patch will replace the ASCII form with their equivalent character codes. This is done by using the [`django-email-obfuscator`](https://github.com/morninj/django-email-obfuscator) app in Django. While this is not a perfect measure to prevent spam, it will at the very least eliminate some of the spam we receive.

The only change around this pull request is to install the app using `pip3`: `pip3 install django-email-obfuscator`. It has no demands for the end user such as having JavaScript enabled, since web browsers are required to covert the character codes to their respective ASCII form.

I have tested this locally on my machine and it works as intended.

When viewing the about page, the [president email address](https://github.com/rit-csc/CSCWebsite/pull/35/commits/2ffcc66fe37dca1cc2aefa80adf07087530ef0e3#diff-5573b7afbe8b5a87526372571cd893ccR72) shows up as desired:

<img width="1006" alt="screen shot 2016-04-26 at 18 44 52" src="https://cloud.githubusercontent.com/assets/407905/14836546/066624c4-0bdf-11e6-96bb-0a2af2018998.png">

When hovering over the link, it will open up what ever app the `mailto` handler is meant to hand off to:

<img width="247" alt="screen shot 2016-04-26 at 18 45 02" src="https://cloud.githubusercontent.com/assets/407905/14836548/06791296-0bdf-11e6-9500-26ab3537a56c.png">

When viewing the page source, it will be in its obfuscated form:

<img width="915" alt="screen shot 2016-04-26 at 18 45 09" src="https://cloud.githubusercontent.com/assets/407905/14836547/0676223e-0bdf-11e6-87b9-bfe8562c348f.png">

This page will also display correctly on the command-line web browser Lynx:

<img width="593" alt="screen shot 2016-04-26 at 18 48 20" src="https://cloud.githubusercontent.com/assets/407905/14836634/8a2ff582-0bdf-11e6-828a-2a495d269409.png">
